### PR TITLE
feat: Create v3 of the war reporting tool

### DIFF
--- a/v3_advanced_report_template.html
+++ b/v3_advanced_report_template.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Advanced War Analysis: {{ our_faction_name }} vs {{ opponent_faction_name }} (War ID: {{ war_id }})</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .card { background-color: #1f2937; border: 1px solid #374151; border-radius: 0.5rem; padding: 1.5rem; margin-bottom: 1.5rem; }
+        .table-header { background-color: #374151; }
+        .table-subheader { background-color: #2b3544; }
+        .table-row-light { background-color: #2b3544; }
+        .table-row-dark { background-color: #1f2937; }
+        .stat-card { background-color: #2b3544; padding: 1rem; border-radius: 0.5rem; text-align: center; }
+        .stat-label { color: #9ca3af; font-size: 0.875rem; }
+        .stat-value { color: #ffffff; font-size: 1.25rem; font-weight: bold; }
+        .text-red-400 { color: #f87171; }
+        .text-green-400 { color: #4ade80; }
+        .text-yellow-400 { color: #facc15; }
+    </style>
+</head>
+<body class="bg-gray-900 text-gray-300 p-4 sm:p-8">
+    <div class="max-w-screen-xl mx-auto" id="report-container">
+        <header class="text-center mb-8">
+            <h1 class="text-4xl font-bold text-white">Ranked War: Advanced Analysis</h1>
+            <h2 class="text-2xl text-cyan-400">{{ our_faction_name }} vs {{ opponent_faction_name }} (War ID: {{ war_id }})</h2>
+        </header>
+
+        <div class="card">
+            <h3 class="text-xl font-semibold text-white mb-4">War Summary</h3>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div class="stat-card">
+                    <div class="stat-label">Top Earner</div>
+                    <div class="stat-value">{{ top_earner.name }}</div>
+                    <div class="stat-label">${{ "{:,.0f}".format(top_earner.payout) }}</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-label">Top Hitter</div>
+                    <div class="stat-value">{{ top_hitter.name }}</div>
+                    <div class="stat-label">{{ top_hitter.hits }} hits</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-label">Total Hits Made</div>
+                    <div class="stat-value">{{ "{:,.0f}".format(totals.hits_made) }}</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-label">Total Respect Gained</div>
+                    <div class="stat-value">{{ "{:,.2f}".format(totals.respect_gained) }}</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3 class="text-xl font-semibold text-white mb-4">Detailed Member Statistics</h3>
+            <div class="overflow-x-auto">
+                <table class="w-full text-left" id="advanced-table">
+                    <thead class="table-header text-xs uppercase">
+                        <tr>
+                            <th rowspan="2" class="p-3">Member</th>
+                            <th colspan="6" class="p-3 text-center">Performance Stats</th>
+                            <th colspan="5" class="p-3 text-center">Financial Breakdown</th>
+                        </tr>
+                        <tr class="table-subheader">
+                            <th class="p-2 text-right">Hits</th>
+                            <th class="p-2 text-right">Defends</th>
+                            <th class="p-2 text-right">Assists</th>
+                            <th class="p-2 text-right">Losses</th>
+                            <th class="p-2 text-right">Stales</th>
+                            <th class="p-2 text-right">Bonus<br>Respect</th>
+                            <th class="p-2 text-right">Guaranteed</th>
+                            <th class="p-2 text-right">Participation</th>
+                            <th class="p-2 text-right">Assist Bonus</th>
+                            <th class="p-2 text-right">Penalty</th>
+                            <th class="p-2 text-right">Final Payout</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for member_id, stats in member_stats %}
+                        <tr class="{{ 'table-row-light' if loop.index is odd else 'table-row-dark' }}">
+                            <td class="p-2 font-semibold">
+                                <a href="https://www.torn.com/profiles.php?XID={{ member_id }}" target="_blank" class="text-cyan-400 hover:underline">{{ stats.name }}</a>
+                            </td>
+                            <td class="p-2 text-right">{{ stats.hits_made }}</td>
+                            <td class="p-2 text-right text-green-400">{{ stats.defends }}</td>
+                            <td class="p-2 text-right">{{ stats.assists }}</td>
+                            <td class="p-2 text-right text-red-400">{{ stats.hits_taken }}</td>
+                            <td class="p-2 text-right">{{ stats.stalemates }}</td>
+                            <td class="p-2 text-right text-yellow-400">{{ "%.2f"|format(stats.respect_gained) }}</td>
+                            <td class="p-2 text-right">${{ "{:,.0f}".format(stats.guaranteed_payout) }}</td>
+                            <td class="p-2 text-right">${{ "{:,.0f}".format(stats.participation_payout) }}</td>
+                            <td class="p-2 text-right text-green-400">${{ "{:,.0f}".format(stats.assist_payout) }}</td>
+                            <td class="p-2 text-right text-red-400">(${{ "{:,.0f}".format(stats.penalty_amount) }})</td>
+                            <td class="p-2 text-right font-bold text-white">${{ "{:,.0f}".format(stats.final_payout) }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                    <tfoot class="table-header font-bold">
+                        <tr>
+                            <td class="p-2">Total</td>
+                            <td class="p-2 text-right">{{ "{:,.0f}".format(totals.hits_made) }}</td>
+                            <td class="p-2 text-right">{{ "{:,.0f}".format(totals.defends) }}</td>
+                            <td class="p-2 text-right">{{ "{:,.0f}".format(totals.assists) }}</td>
+                            <td class="p-2 text-right">{{ "{:,.0f}".format(totals.hits_taken) }}</td>
+                            <td class="p-2 text-right">{{ "{:,.0f}".format(totals.stalemates) }}</td>
+                            <td class="p-2 text-right">{{ "%.2f"|format(totals.respect_gained) }}</td>
+                            <td class="p-2 text-right">${{ "{:,.0f}".format(totals.guaranteed_payout) }}</td>
+                            <td class="p-2 text-right">${{ "{:,.0f}".format(totals.participation_payout) }}</td>
+                            <td class="p-2 text-right">${{ "{:,.0f}".format(totals.assist_payout) }}</td>
+                            <td class="p-2 text-right">(${{ "{:,.0f}".format(totals.penalty_amount) }})</td>
+                            <td class="p-2 text-right">${{ "{:,.0f}".format(totals.final_payout) }}</td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        </div>
+
+        <div class="mt-8 flex justify-center space-x-4">
+             <button id="csvButton" class="p-4 rounded-md bg-green-700 hover:bg-green-800" title="Export to CSV">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+            </button>
+            <button id="screenshotButton" class="p-4 rounded-md bg-blue-600 hover:bg-blue-700" title="Download Screenshot">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
+                </svg>
+            </button>
+        </div>
+    </div>
+    <script>
+        function takeScreenshot() {
+            const reportContainer = document.getElementById('report-container');
+            const buttonsParent = document.querySelector('.mt-8.flex');
+            buttonsParent.style.display = 'none';
+            html2canvas(reportContainer, { backgroundColor: '#111827', windowWidth: reportContainer.scrollWidth, windowHeight: reportContainer.scrollHeight })
+                .then(canvas => {
+                    const link = document.createElement('a');
+                    link.download = `advanced_war_report_{{ war_id }}.png`;
+                    link.href = canvas.toDataURL('image/png');
+                    link.click();
+                    buttonsParent.style.display = 'flex';
+                });
+        }
+
+        function exportTableToCSV(filename) {
+            let csv = [];
+            const table = document.getElementById("advanced-table");
+            const headers = [];
+            // Get main headers, accounting for colspan
+            table.querySelectorAll("thead tr:first-child th").forEach(th => {
+                const text = th.textContent.trim();
+                const colspan = th.colSpan || 1;
+                headers.push(text);
+                for(let i = 1; i < colspan; i++) { headers.push(''); }
+            });
+            csv.push(headers.join(','));
+
+            const subHeaders = [];
+            // Get subheaders
+            table.querySelectorAll("thead tr:last-child th").forEach(th => {
+                subHeaders.push('"' + th.textContent.trim().replace(/<br>/g, ' ') + '"');
+            });
+            csv.push(subHeaders.join(','));
+
+            // Get rows
+            table.querySelectorAll("tbody tr").forEach(row => {
+                const rowData = [];
+                row.querySelectorAll("td").forEach(td => {
+                    rowData.push('"' + td.textContent.trim().replace(/\$|,|\(|\)/g, '') + '"');
+                });
+                csv.push(rowData.join(','));
+            });
+
+             // Get footer
+            const footerData = [];
+            table.querySelectorAll("tfoot tr td").forEach(td => {
+                 footerData.push('"' + td.textContent.trim().replace(/\$|,|\(|\)/g, '') + '"');
+            });
+            csv.push(footerData.join(','))
+
+
+            const csvFile = new Blob([csv.join("\n")], { type: "text/csv" });
+            const downloadLink = document.createElement("a");
+            downloadLink.download = filename;
+            downloadLink.href = window.URL.createObjectURL(csvFile);
+            downloadLink.style.display = "none";
+            document.body.appendChild(downloadLink);
+            downloadLink.click();
+        }
+
+        document.getElementById('screenshotButton').addEventListener('click', takeScreenshot);
+        document.getElementById('csvButton').addEventListener('click', () => {
+             exportTableToCSV('advanced_war_report_{{ war_id }}.csv');
+        });
+    </script>
+</body>
+</html>

--- a/v3_config.ini
+++ b/v3_config.ini
@@ -1,0 +1,24 @@
+[TornAPI]
+ApiKey = MQvdE3zm8IGmZptt
+
+[Defaults]
+FactionShare = 30
+GuaranteedShare = 10
+
+[Preset_Standard]
+use_bonus_respect = true
+assist_payment_type = none
+assist_payment_value = 0
+penalty_per_hit_taken = 0
+
+[Preset_NoBonus_AssistsFlat]
+use_bonus_respect = false
+assist_payment_type = flat
+assist_payment_value = 250000
+penalty_per_hit_taken = 0
+
+[Preset_Penalties]
+use_bonus_respect = false
+assist_payment_type = none
+assist_payment_value = 0
+penalty_per_hit_taken = 500000

--- a/v3_report_template.html
+++ b/v3_report_template.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>War Report: {{ our_faction_name }} vs {{ opponent_faction_name }} (War ID: {{ war_id }})</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .card { background-color: #1f2937; border: 1px solid #374151; border-radius: 0.5rem; padding: 1.5rem; margin-bottom: 1.5rem; }
+        .table-header { background-color: #374151; }
+        .table-row-light { background-color: #2b3544; }
+        .info-row { display: flex; align-items: center; padding: 0.5rem 0; }
+        .info-label { font-weight: bold; color: #9ca3af; margin-right: 1rem; flex-shrink: 0; min-width: 150px; }
+        .info-value { color: #ffffff; flex-grow: 1; }
+        .highlight-row { background-color: #4b5563; }
+        .text-red-400 { color: #f87171; }
+        .text-green-400 { color: #4ade80; }
+    </style>
+</head>
+<body class="bg-gray-900 text-gray-300 p-4 sm:p-8">
+    <div class="max-w-7xl mx-auto" id="report-container">
+        <header class="text-center mb-8">
+            <h1 class="text-4xl font-bold text-white">Ranked War Payout Report</h1>
+            <h2 class="text-2xl text-cyan-400">{{ our_faction_name }} vs {{ opponent_faction_name }} (War ID: {{ war_id }})</h2>
+        </header>
+
+        <div class="card">
+             <div class="info-row">
+                <span class="info-label">Start Date:</span>
+                <span class="info-value">{{ start_str }}</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">End Date:</span>
+                <span class="info-value">{{ end_str }}</span>
+            </div>
+        </div>
+
+        <div class="card">
+            <h3 class="text-xl font-semibold text-white mb-4">Member Contributions & Payouts</h3>
+            <div class="overflow-x-auto">
+                <table class="w-full text-left">
+                    <thead class="table-header">
+                        <tr>
+                            <th class="p-3">Status</th>
+                            <th class="p-3">Member</th>
+                            <th class="p-3 text-right">Respect Gained</th>
+                            <th class="p-3 text-right">Respect Payout</th>
+                            <th class="p-3 text-right">Adjustments</th>
+                            <th class="p-3 text-right">Final Payout</th>
+                        </tr>
+                    </thead>
+                    <tbody id="member-table-body">
+                        {% for member_id, stats in member_stats %}
+                        <tr class="table-row-light"
+                            data-enabled="true"
+                            data-member-id="{{ member_id }}"
+                            data-respect-payout="{{ '%.0f'|format(stats.respect_payout) }}"
+                            data-adjustments="{{ '%.0f'|format(stats.adjustments) }}"
+                            data-final-payout="{{ '%.0f'|format(stats.final_payout) }}">
+                            <td class="p-3">
+                                <button class="status-toggle p-1 rounded-full bg-green-500 hover:bg-green-600">
+                                    <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                </button>
+                            </td>
+                            <td class="p-3 cursor-pointer" onclick="copyMemberInfo(this, '{{ stats.name }}', '{{ member_id }}')">
+                                <a href="https://www.torn.com/profiles.php?XID={{ member_id }}" target="_blank" class="text-cyan-400 hover:underline">{{ stats.name }} [{{ member_id }}]</a>
+                            </td>
+                            <td class="p-3 text-right">{{ '%.2f'|format(stats.respect_gained) }}</td>
+                            <td class="p-3 text-right text-yellow-400 font-semibold respect-payout">${{ "{:,.0f}".format(stats.respect_payout) }}</td>
+                            <td class="p-3 text-right font-semibold {% if stats.adjustments < 0 %}text-red-400{% else %}text-green-400{% endif %} adjustments">${{ "{:,.0f}".format(stats.adjustments) }}</td>
+                            <td class="p-3 text-right text-white font-bold total-prize">
+                                <a href="https://www.torn.com/factions.php?step=your#/tab=controls&option=give-to-user&addMoneyTo={{ member_id }}&money={{ '%.0f'|format(stats.final_payout) }}" target="_blank" class="text-white hover:underline" onclick="highlightRow(this.closest('tr'));">
+                                    ${{ "{:,.0f}".format(stats.final_payout) }}
+                                </a>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                    <tfoot>
+                        <tr class="table-header font-bold">
+                            <td class="p-3" colspan="3">Total (for enabled members)</td>
+                            <td id="total-respect-payout" class="p-3 text-right">${{ "{:,.0f}".format(total_respect_payout) }}</td>
+                            <td id="total-adjustments" class="p-3 text-right">${{ "{:,.0f}".format(total_adjustments) }}</td>
+                            <td id="total-final-payout" class="p-3 text-right">${{ "{:,.0f}".format(total_final_payout) }}</td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        </div>
+
+        <div class="mt-8 flex justify-center space-x-4">
+             <button id="screenshotButton" class="p-4 rounded-md bg-blue-600 hover:bg-blue-700" title="Download Screenshot">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-white" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
+                </svg>
+            </button>
+        </div>
+    </div>
+    <script>
+        const warId = '{{ war_id }}';
+
+        function updateTotals() {
+            const memberRows = document.querySelectorAll('#member-table-body tr');
+            let totalRespectPayout = 0;
+            let totalAdjustments = 0;
+            let totalFinalPayout = 0;
+
+            memberRows.forEach(row => {
+                if (row.dataset.enabled === 'true') {
+                    totalRespectPayout += parseFloat(row.dataset.respectPayout) || 0;
+                    totalAdjustments += parseFloat(row.dataset.adjustments) || 0;
+                    totalFinalPayout += parseFloat(row.dataset.finalPayout) || 0;
+                }
+            });
+
+            document.getElementById('total-respect-payout').textContent = `$` + Math.round(totalRespectPayout).toLocaleString();
+            document.getElementById('total-adjustments').textContent = `$` + Math.round(totalAdjustments).toLocaleString();
+            document.getElementById('total-final-payout').textContent = `$` + Math.round(totalFinalPayout).toLocaleString();
+        }
+
+        function togglePlayerStatus(button) {
+            const row = button.closest('tr');
+            const isEnabled = row.dataset.enabled === 'true';
+            if (isEnabled) {
+                row.dataset.enabled = 'false';
+                button.classList.remove('bg-green-500', 'hover:bg-green-600');
+                button.classList.add('bg-red-500', 'hover:bg-red-600');
+                button.innerHTML = `<svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>`;
+                row.style.opacity = '0.5';
+            } else {
+                row.dataset.enabled = 'true';
+                button.classList.remove('bg-red-500', 'hover:bg-red-600');
+                button.classList.add('bg-green-500', 'hover:bg-green-600');
+                button.innerHTML = `<svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>`;
+                row.style.opacity = '1.0';
+            }
+            updateTotals();
+        }
+
+        let lastHighlightedRow = null;
+        function highlightRow(row) {
+            if (lastHighlightedRow) { lastHighlightedRow.classList.remove('highlight-row'); }
+            row.classList.add('highlight-row');
+            lastHighlightedRow = row;
+        }
+
+        function copyMemberInfo(element, memberName, memberId) {
+            highlightRow(element.closest('tr'));
+            navigator.clipboard.writeText(`${memberName} [${memberId}]`);
+        }
+
+        function takeScreenshot() {
+            const reportContainer = document.getElementById('report-container');
+            const buttonsParent = document.querySelector('.mt-8.flex');
+            buttonsParent.style.display = 'none';
+            html2canvas(reportContainer, { backgroundColor: '#111827', windowWidth: reportContainer.scrollWidth, windowHeight: reportContainer.scrollHeight })
+                .then(canvas => {
+                    const link = document.createElement('a');
+                    link.download = `war_report_${warId}.png`;
+                    link.href = canvas.toDataURL('image/png');
+                    link.click();
+                    buttonsParent.style.display = 'flex';
+                });
+        }
+
+        document.querySelectorAll('.status-toggle').forEach(button => { button.addEventListener('click', () => togglePlayerStatus(button)); });
+        document.getElementById('screenshotButton').addEventListener('click', takeScreenshot);
+
+        window.onload = updateTotals;
+    </script>
+</body>
+</html>

--- a/v3_war_report.py
+++ b/v3_war_report.py
@@ -1,0 +1,526 @@
+import requests
+import json
+import time
+from datetime import datetime
+import argparse
+import sys
+import os
+import configparser
+import logging
+from jinja2 import Environment, FileSystemLoader
+
+# Define constants for directories
+CACHE_DIR = 'cache'
+REPORTS_DIR = 'reports'
+
+# --- Configuration ---
+def get_config(config_filename="v3_config.ini"):
+    """Reads configuration from a given .ini file and returns it as a dictionary."""
+    config_parser = configparser.ConfigParser()
+    config = {
+        'api_key': None,
+        'faction_share_default': '30',
+        'guaranteed_share_default': '10',
+        'presets': {}
+    }
+
+    if not os.path.exists(config_filename):
+        logging.error(f"{config_filename} file not found. Please create it.")
+        return None
+
+    config_parser.read(config_filename)
+
+    # Read API Key
+    if 'TornAPI' in config_parser and 'ApiKey' in config_parser['TornAPI']:
+        key = config_parser['TornAPI']['ApiKey']
+        if key and key.strip() and key != 'YourActualApiKeyHere':
+            config['api_key'] = key
+        else:
+            logging.error(f"API key not set in {config_filename}.")
+            return None
+    else:
+        logging.error(f"[TornAPI] section or ApiKey not found in {config_filename}.")
+        return None
+
+    # Read Defaults, but don't fail if they're missing
+    if 'Defaults' in config_parser:
+        config['faction_share_default'] = config_parser['Defaults'].get('FactionShare', config['faction_share_default'])
+        config['guaranteed_share_default'] = config_parser['Defaults'].get('GuaranteedShare', config['guaranteed_share_default'])
+
+    # Read Presets
+    for section in config_parser.sections():
+        if section.startswith('Preset_'):
+            config['presets'][section] = dict(config_parser.items(section))
+
+    return config
+
+# --- Utility Functions ---
+def get_unique_filename(base_path):
+    """Checks if a file exists and returns a unique name by appending a number."""
+    if not os.path.exists(base_path):
+        return base_path
+
+    directory, filename = os.path.split(base_path)
+    name, ext = os.path.splitext(filename)
+
+    counter = 2
+    while True:
+        new_name = f"{name}_{counter}{ext}"
+        new_path = os.path.join(directory, new_name)
+        if not os.path.exists(new_path):
+            return new_path
+        counter += 1
+
+def prompt_for_numeric_input(prompt_message, default=None):
+    """Prompts the user for numeric input, allowing an optional default value."""
+    while True:
+        prompt_suffix = f" (default: {default})" if default is not None else ""
+        user_input = input(f"{prompt_message}{prompt_suffix}: ")
+
+        if user_input.strip() == "" and default is not None:
+            return str(default)
+
+        cleaned_input = user_input.replace(',', '').replace('$', '').strip()
+
+        if cleaned_input.isdigit():
+            return cleaned_input
+        else:
+            logging.warning("Invalid input. Please enter a whole number or press Enter to use the default.")
+
+# --- API Fetching Functions ---
+def get_api_data(url):
+    """Fetches data from a given Torn API URL."""
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        data = response.json()
+        if 'error' in data:
+            logging.error(f"API Error: {data['error']['error']}")
+            return None
+        return data
+    except requests.exceptions.RequestException as e:
+        logging.error(f"An HTTP error occurred: {e}")
+        return None
+    except ValueError:
+        logging.error("Error decoding JSON from response.")
+        return None
+
+def get_war_details(war_id, api_key):
+    """Fetches the details of a specific ranked war."""
+    logging.info(f"Fetching details for War ID: {war_id}...")
+    url = f"https://api.torn.com/torn/{war_id}?selections=rankedwarreport&key={api_key}"
+    return get_api_data(url)
+
+def get_all_attacks(faction_id, start_timestamp, end_timestamp, api_key):
+    """Fetches all faction attacks within a given timeframe."""
+    start_str = datetime.fromtimestamp(start_timestamp).strftime('%Y-%m-%d %H:%M:%S')
+    end_str = datetime.fromtimestamp(end_timestamp).strftime('%Y-%m-%d %H:%M:%S')
+    logging.info(f"Fetching all attack logs from {start_str} to {end_str}...")
+    all_attacks = []
+    current_from = start_timestamp
+
+    while current_from < end_timestamp:
+        url = f"https://api.torn.com/faction/{faction_id}?selections=attacks&from={current_from}&to={end_timestamp}&key={api_key}"
+        data = get_api_data(url)
+        if data and 'attacks' in data:
+            attacks_chunk = list(data['attacks'].values())
+            if not attacks_chunk:
+                break
+            all_attacks.extend(attacks_chunk)
+
+            last_timestamp = attacks_chunk[-1]['timestamp_ended']
+            if last_timestamp > current_from:
+                 current_from = last_timestamp
+            else:
+                 break
+            logging.info(f"Fetched {len(attacks_chunk)} attacks, advancing to timestamp {current_from}")
+            time.sleep(3)
+        else:
+            break
+
+    logging.info(f"Finished fetching. Total attacks: {len(all_attacks)}")
+    unique_attacks = list({attack['code']: attack for attack in all_attacks}.values())
+    logging.info(f"Unique attacks after de-duplication: {len(unique_attacks)}")
+    return unique_attacks
+
+# --- Data Processing Functions ---
+def process_war_data(war_report, all_attacks, our_faction_id):
+    """Processes the raw API data to calculate member contributions."""
+    logging.info("Processing war data...")
+    war_data = war_report.get('rankedwarreport', {})
+
+    factions = war_data.get('factions', {})
+    opponent_faction_id = None
+    for fid, details in factions.items():
+        if int(fid) != our_faction_id:
+            opponent_faction_id = int(fid)
+            break
+
+    if not opponent_faction_id:
+        logging.error("Could not determine opponent faction.")
+        return None
+
+    logging.info(f"Our Faction ID: {our_faction_id}, Opponent Faction ID: {opponent_faction_id}")
+
+    member_stats = {}
+    our_members_in_war = war_data.get('factions', {}).get(str(our_faction_id), {}).get('members', {})
+    logging.info(f"Found {len(our_members_in_war)} members from our faction in the war report.")
+    for member_id, member_details in our_members_in_war.items():
+        member_stats[member_id] = {
+            'name': member_details.get('name', 'Unknown'),
+            'respect_gained': 0.0,
+            'base_respect_gained': 0.0,
+            'hits_made': 0,
+            'assists': 0,
+            'hits_taken': 0,
+            'defends': 0,
+            'stalemates': 0
+        }
+
+    if all_attacks:
+        offensive_hits = 0
+        defensive_hits = 0
+        for attack in all_attacks:
+            if attack.get('ranked_war') != 1:
+                continue
+
+            attacker_id_str = str(attack.get('attacker_id'))
+            defender_id_str = str(attack.get('defender_id'))
+
+            is_offensive = (attack.get('attacker_faction') == our_faction_id and
+                            attack.get('defender_faction') == opponent_faction_id)
+
+            if is_offensive and attacker_id_str in member_stats:
+                offensive_hits += 1
+                member_stats[attacker_id_str]['hits_made'] += 1
+                respect_gain = float(attack.get('respect_gain', 0.0))
+                member_stats[attacker_id_str]['respect_gained'] += respect_gain
+
+                chain_bonus = float(attack.get('modifiers', {}).get('chain_bonus', 1.0) or 1.0)
+                base_respect = respect_gain / chain_bonus
+                member_stats[attacker_id_str]['base_respect_gained'] += base_respect
+
+                if attack.get('result') == 'Assist':
+                    member_stats[attacker_id_str]['assists'] += 1
+
+            is_defensive = (attack.get('defender_faction') == our_faction_id and
+                            attack.get('attacker_faction') == opponent_faction_id)
+
+            if is_defensive and defender_id_str in member_stats:
+                defensive_hits += 1
+                result = attack.get('result')
+                if result == 'Lost':
+                    member_stats[defender_id_str]['hits_taken'] += 1
+                elif result == 'Stalemate':
+                    member_stats[defender_id_str]['stalemates'] += 1
+                else:
+                    member_stats[defender_id_str]['defends'] += 1
+
+        logging.info(f"Processed {offensive_hits} offensive attacks and {defensive_hits} defensive actions.")
+
+    active_members = {mid: stats for mid, stats in member_stats.items() if stats['respect_gained'] > 0}
+    sorted_stats = sorted(active_members.items(), key=lambda item: item[1]['respect_gained'], reverse=True)
+
+    return {
+        'war_details': war_data,
+        'member_stats': sorted_stats,
+        'our_faction_name': factions.get(str(our_faction_id), {}).get('name', 'Your Faction'),
+        'opponent_faction_name': factions.get(str(opponent_faction_id), {}).get('name', 'Opponent')
+    }
+
+def calculate_final_payouts(settings, member_stats, prize_total_str, faction_share_str, guaranteed_share_str):
+    """Calculates final dollar amounts for each member based on selected settings."""
+    logging.info("Calculating final payouts based on settings...")
+
+    try:
+        prize_total = int(str(prize_total_str).replace(',', '').replace('$', '').strip())
+        faction_share_percent = int(faction_share_str)
+        guaranteed_share_percent = int(guaranteed_share_str)
+    except (ValueError, TypeError):
+        logging.error("Invalid numeric value provided for payout calculation.")
+        return member_stats
+
+    use_bonus_respect = settings.get('use_bonus_respect', 'true').lower() == 'true'
+    assist_payment_type = settings.get('assist_payment_type', 'none')
+    assist_payment_value = int(settings.get('assist_payment_value', '0'))
+    penalty_per_hit_taken = int(settings.get('penalty_per_hit_taken', '0'))
+
+    member_data = dict(member_stats)
+    if not member_data:
+        logging.warning("No member data to calculate payouts for.")
+        return []
+
+    participant_count = len(member_data)
+
+    faction_take = prize_total * (faction_share_percent / 100)
+    member_pool = prize_total - faction_take
+
+    guaranteed_pool = member_pool * (guaranteed_share_percent / 100)
+    guaranteed_payout_per_member = guaranteed_pool / participant_count if participant_count > 0 else 0
+
+    adjustable_pool = member_pool - guaranteed_pool
+
+    total_assists = sum(stats['assists'] for stats in member_data.values())
+    total_hits_taken = sum(stats['hits_taken'] for stats in member_data.values())
+
+    total_assist_payout = 0
+    if assist_payment_type == 'flat':
+        total_assist_payout = total_assists * assist_payment_value
+
+    total_penalty_deductions = total_hits_taken * penalty_per_hit_taken
+
+    participation_pool = adjustable_pool - total_assist_payout - total_penalty_deductions
+    if participation_pool < 0:
+        logging.warning(f"Participation pool is negative (${participation_pool:,.2f}). Payouts from respect share will be zero.")
+        participation_pool = 0
+
+    respect_key = 'respect_gained' if use_bonus_respect else 'base_respect_gained'
+    total_respect_to_share = sum(stats[respect_key] for stats in member_data.values())
+
+    for _, stats in member_data.items():
+        stats['guaranteed_payout'] = guaranteed_payout_per_member
+        stats['penalty_amount'] = stats['hits_taken'] * penalty_per_hit_taken
+
+        stats['assist_payout'] = 0
+        if assist_payment_type == 'flat':
+            stats['assist_payout'] = stats['assists'] * assist_payment_value
+
+        member_respect = stats[respect_key]
+        respect_share_percent = (member_respect / total_respect_to_share) if total_respect_to_share > 0 else 0
+        stats['participation_payout'] = participation_pool * respect_share_percent
+
+        stats['adjustments'] = stats['assist_payout'] - stats['penalty_amount']
+        stats['respect_payout'] = stats['guaranteed_payout'] + stats['participation_payout']
+        stats['final_payout'] = stats['respect_payout'] + stats['adjustments']
+
+    sorted_member_data = sorted(member_data.items(), key=lambda item: item[1]['final_payout'], reverse=True)
+
+    logging.info("Finished calculating payouts.")
+    return sorted_member_data
+
+# --- HTML Generation Functions ---
+def generate_war_report_html(processed_data, war_id, prize_total, faction_share, guaranteed_share):
+    """Generates the final simple HTML report file using a Jinja2 template."""
+    if not processed_data or not processed_data.get('member_stats'):
+        logging.warning("No participating members found with respect gained. Report generation skipped.")
+        return
+
+    env = Environment(loader=FileSystemLoader('.'))
+    try:
+        template = env.get_template('v3_report_template.html')
+    except FileNotFoundError:
+        logging.error("v3_report_template.html not found in the script's directory.")
+        return
+
+    member_stats = processed_data['member_stats']
+    total_respect_payout = sum(stats.get('respect_payout', 0) for _, stats in member_stats)
+    total_adjustments = sum(stats.get('adjustments', 0) for _, stats in member_stats)
+    total_final_payout = sum(stats.get('final_payout', 0) for _, stats in member_stats)
+
+    war_details = processed_data['war_details']
+    context = {
+        'war_id': war_id,
+        'our_faction_name': processed_data['our_faction_name'],
+        'opponent_faction_name': processed_data['opponent_faction_name'],
+        'start_str': datetime.fromtimestamp(war_details['war']['start']).strftime('%Y-%m-%d %H:%M:%S'),
+        'end_str': datetime.fromtimestamp(war_details['war']['end']).strftime('%Y-%m-%d %H:%M:%S'),
+        'member_stats': member_stats,
+        'total_respect_gained': sum(stats['respect_gained'] for _, stats in member_stats),
+        'total_respect_payout': total_respect_payout,
+        'total_adjustments': total_adjustments,
+        'total_final_payout': total_final_payout
+    }
+
+    html_content = template.render(context)
+
+    opponent_name_safe = processed_data['opponent_faction_name'].replace(' ', '_').replace('[', '').replace(']', '')
+    base_filename = f"v3_war_report_{war_id}_{opponent_name_safe}.html"
+    report_path = os.path.join(REPORTS_DIR, base_filename)
+    unique_filename = get_unique_filename(report_path)
+
+    with open(unique_filename, "w", encoding="utf-8") as f:
+        f.write(html_content)
+    logging.info(f"Successfully generated simple report: {unique_filename}")
+
+
+def generate_advanced_report_html(processed_data, war_id):
+    """Generates the final advanced HTML report file using a Jinja2 template."""
+    if not processed_data or not processed_data.get('member_stats'):
+        logging.warning("No data for advanced report. Generation skipped.")
+        return
+
+    env = Environment(loader=FileSystemLoader('.'))
+    try:
+        template = env.get_template('v3_advanced_report_template.html')
+    except FileNotFoundError:
+        logging.error("v3_advanced_report_template.html not found in the script's directory.")
+        return
+
+    member_stats = processed_data['member_stats']
+
+    # Calculate totals for all columns
+    totals = {
+        key: sum(stats.get(key, 0) for _, stats in member_stats)
+        for key in ['hits_made', 'defends', 'assists', 'hits_taken', 'stalemates', 'respect_gained',
+                    'guaranteed_payout', 'participation_payout', 'assist_payout', 'penalty_amount', 'final_payout']
+    }
+
+    # Find top performers
+    top_earner_stats = member_stats[0][1] if member_stats else {'name': 'N/A', 'final_payout': 0}
+    top_hitter = max(member_stats, key=lambda item: item[1]['hits_made']) if member_stats else ('', {'name': 'N/A', 'hits_made': 0})
+
+    war_details = processed_data['war_details']
+    context = {
+        'war_id': war_id,
+        'our_faction_name': processed_data['our_faction_name'],
+        'opponent_faction_name': processed_data['opponent_faction_name'],
+        'start_str': datetime.fromtimestamp(war_details['war']['start']).strftime('%Y-%m-%d %H:%M:%S'),
+        'end_str': datetime.fromtimestamp(war_details['war']['end']).strftime('%Y-%m-%d %H:%M:%S'),
+        'member_stats': member_stats,
+        'totals': totals,
+        'top_earner': {'name': top_earner_stats['name'], 'payout': top_earner_stats['final_payout']},
+        'top_hitter': {'name': top_hitter[1]['name'], 'hits': top_hitter[1]['hits_made']}
+    }
+
+    html_content = template.render(context)
+
+    opponent_name_safe = processed_data['opponent_faction_name'].replace(' ', '_').replace('[', '').replace(']', '')
+    base_filename = f"v3_advanced_report_{war_id}_{opponent_name_safe}.html"
+    report_path = os.path.join(REPORTS_DIR, base_filename)
+    unique_filename = get_unique_filename(report_path)
+
+    with open(unique_filename, "w", encoding="utf-8") as f:
+        f.write(html_content)
+    logging.info(f"Successfully generated advanced report: {unique_filename}")
+
+
+# --- Main Execution ---
+def main():
+    """Main function to generate the war report."""
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    os.makedirs(REPORTS_DIR, exist_ok=True)
+
+    config = get_config("v3_config.ini")
+    if not config or not config.get('api_key'):
+        sys.exit(1)
+
+    API_KEY = config['api_key']
+
+    # --- Argument Parsing ---
+    parser = argparse.ArgumentParser(
+        description="Generate a ranked war report for Torn.com.",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""
+Usage Examples:
+-----------------
+1. Interactive Mode (will prompt for all inputs):
+   python v3_war_report.py
+
+2. Basic Report (using default shares from config.ini):
+   python v3_war_report.py 28997
+
+3. Report with Custom Payouts:
+   python v3_war_report.py 28997 --prize-total 1000000000 --faction-share 25 --guaranteed-share 5
+
+4. Force Refresh (ignore and overwrite cache):
+   python v3_war_report.py 28997 --no-cache
+
+5. Using a Payout Preset from config.ini:
+   python v3_war_report.py 28997 --prize-total 1b --preset Preset_NoBonus_AssistsFlat
+"""
+    )
+    parser.add_argument('war_id', nargs='?', default=None, help='The ranked war ID. Required for non-interactive mode.')
+    parser.add_argument('-p', '--prize-total', type=str, help='The total prize money for the war (e.g., 1000000000).')
+    parser.add_argument('-f', '--faction-share', type=str, help=f"The percentage of the prize the faction keeps. Default: {config['faction_share_default']}%%")
+    parser.add_argument('-g', '--guaranteed-share', type=str, help=f"The percentage of the member pool for guaranteed payouts. Default: {config['guaranteed_share_default']}%%")
+    parser.add_argument('--preset', type=str, help='The name of the payout preset to use from config.ini (e.g., Preset_Standard).')
+    parser.add_argument('--no-cache', action='store_true', help='Ignore existing cache and fetch fresh attack data from the API.')
+
+    args = parser.parse_args()
+
+    # --- Determine Mode (Interactive vs. Argument-driven) ---
+    if args.war_id:
+        # Argument-driven mode
+        war_id = args.war_id
+        prize_total = args.prize_total if args.prize_total is not None else "0"
+        faction_share = args.faction_share if args.faction_share is not None else config['faction_share_default']
+        guaranteed_share = args.guaranteed_share if args.guaranteed_share is not None else config['guaranteed_share_default']
+    else:
+        # Interactive mode
+        logging.info("No War ID provided. Entering interactive mode.")
+        war_id = prompt_for_numeric_input("Please enter the Ranked War ID")
+        logging.info("Please provide payout details (press Enter to use defaults):")
+        prize_total = prompt_for_numeric_input("Prize Total", default="0")
+        faction_share = prompt_for_numeric_input("Faction Share %", default=config['faction_share_default'])
+        guaranteed_share = prompt_for_numeric_input("Guaranteed Share %", default=config['guaranteed_share_default'])
+
+    # --- Start processing and API calls ---
+    war_report = get_war_details(war_id, API_KEY)
+    if not war_report or 'rankedwarreport' not in war_report:
+        logging.error("Could not fetch war report. Check the War ID and API key.")
+        sys.exit(1)
+
+    user_data = get_api_data(f"https://api.torn.com/user/?selections=profile&key={API_KEY}")
+    if not user_data or 'faction' not in user_data or user_data['faction']['faction_id'] == 0:
+        logging.error("Could not determine your faction ID from the API key provided.")
+        sys.exit(1)
+
+    our_faction_id = user_data['faction']['faction_id']
+    war_start_time = war_report['rankedwarreport']['war']['start']
+    war_end_time = war_report['rankedwarreport']['war']['end']
+
+    # --- Caching logic for attack logs ---
+    cache_file_path = os.path.join(CACHE_DIR, f"v3_war_hits_cache_{war_id}.json")
+    all_attacks = None
+
+    if not args.no_cache and os.path.exists(cache_file_path):
+        logging.info(f"Loading attack data from cache: {cache_file_path}")
+        try:
+            with open(cache_file_path, 'r', encoding='utf-8') as f:
+                all_attacks = json.load(f)
+            logging.info(f"Successfully loaded {len(all_attacks)} unique attacks from cache.")
+        except (json.JSONDecodeError, IOError) as e:
+            logging.warning(f"Could not read cache file {cache_file_path}: {e}. Refetching from API.")
+            all_attacks = None
+
+    if all_attacks is None:
+        logging.info("Cache not found or invalid. Fetching attacks from API...")
+        fetch_start_time = war_start_time - 330
+        fetch_end_time = war_end_time + 330
+        all_attacks = get_all_attacks(our_faction_id, fetch_start_time, fetch_end_time, API_KEY)
+
+        if all_attacks:
+            logging.info(f"Saving attack data to cache: {cache_file_path}")
+            with open(cache_file_path, 'w', encoding='utf-8') as f:
+                json.dump(all_attacks, f, indent=4)
+
+    processed_data = process_war_data(war_report, all_attacks, our_faction_id)
+
+    if processed_data:
+        # --- Payout Calculation ---
+        if processed_data.get('member_stats'):
+            active_preset = {}
+            if args.preset:
+                if args.preset in config['presets']:
+                    active_preset = config['presets'][args.preset]
+                    logging.info(f"Using '{args.preset}' preset for payout calculations.")
+                else:
+                    logging.warning(f"Preset '{args.preset}' not found in config.ini. Using default calculation logic.")
+
+            calculated_stats = calculate_final_payouts(
+                settings=active_preset,
+                member_stats=processed_data['member_stats'],
+                prize_total_str=prize_total,
+                faction_share_str=faction_share,
+                guaranteed_share_str=guaranteed_share
+            )
+            processed_data['member_stats'] = calculated_stats
+
+        # --- Report Generation ---
+        generate_war_report_html(processed_data, war_id, prize_total, faction_share, guaranteed_share)
+        generate_advanced_report_html(processed_data, war_id)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit introduces a new, advanced version of the war reporting tool, identified by the `v3_` prefix. This approach was taken to keep the new version separate from the original script while working around environment issues with directory creation.

The new version includes:
- A powerful data processing engine that calculates detailed member statistics, including hits, defends, assists, losses, and base respect.
- A preset-driven financial calculation engine that allows for flexible payout rules based on settings in `v3_config.ini`.
- A simplified, clean HTML report for easy sharing of final payouts.
- A new advanced analysis HTML report with detailed performance stats and a full financial breakdown for in-depth analysis.
- The advanced report includes a button to export the data to CSV.

The new files are:
- `v3_war_report.py`: The main script for the new version.
- `v3_report_template.html`: The template for the simple report.
- `v3_advanced_report_template.html`: The template for the advanced report.
- `v3_config.ini`: The configuration file for the new version.